### PR TITLE
Implemented functionality to set scan page limit || As it fixed the open issue #15 

### DIFF
--- a/android/src/main/kotlin/com/shirsh/flutter_doc_scanner/FlutterDocScannerPlugin.kt
+++ b/android/src/main/kotlin/com/shirsh/flutter_doc_scanner/FlutterDocScannerPlugin.kt
@@ -52,26 +52,27 @@ class FlutterDocScannerPlugin : MethodCallHandler, ActivityResultListener,
         if (call.method == "getPlatformVersion") {
             result.success("Android ${android.os.Build.VERSION.RELEASE}")
         } else if (call.method == "getScanDocuments") {
+            val arguments = call.arguments as? Map<*, *>
+            val page = (arguments?.get("page") as? Int)?.coerceAtLeast(1) ?: 5
             resultChannel = result
-            startDocumentScan()
+            startDocumentScan(page)
         } else if (call.method == "getScanDocumentsUri") {
+            val arguments = call.arguments as? Map<*, *>
+            val page = (arguments?.get("page") as? Int)?.coerceAtLeast(1) ?: 5
             resultChannel = result
-            startDocumentScanUri()
+            startDocumentScanUri(page)
         } else {
             result.notImplemented()
         }
     }
 
-    private fun startDocumentScan() {
-        val options = GmsDocumentScannerOptions.Builder()
-            .setGalleryImportAllowed(true)
-            .setPageLimit(9)
-            .setResultFormats(
-                GmsDocumentScannerOptions.RESULT_FORMAT_JPEG,
-                GmsDocumentScannerOptions.RESULT_FORMAT_PDF
-            )
-            .setScannerMode(GmsDocumentScannerOptions.SCANNER_MODE_FULL)
-            .build()
+    private fun startDocumentScan(page: Int = 5) {
+        val options =
+            GmsDocumentScannerOptions.Builder().setGalleryImportAllowed(true).setPageLimit(page)
+                .setResultFormats(
+                    GmsDocumentScannerOptions.RESULT_FORMAT_JPEG,
+                    GmsDocumentScannerOptions.RESULT_FORMAT_PDF
+                ).setScannerMode(GmsDocumentScannerOptions.SCANNER_MODE_FULL).build()
         val scanner = GmsDocumentScanning.getClient(options)
         val task: Task<IntentSender>? = activity?.let { scanner.getStartScanIntent(it) }
         task?.addOnSuccessListener { intentSender ->
@@ -96,16 +97,13 @@ class FlutterDocScannerPlugin : MethodCallHandler, ActivityResultListener,
         }
     }
 
-    private fun startDocumentScanUri() {
-        val options = GmsDocumentScannerOptions.Builder()
-            .setGalleryImportAllowed(true)
-            .setPageLimit(9)
-            .setResultFormats(
-                GmsDocumentScannerOptions.RESULT_FORMAT_JPEG,
-                GmsDocumentScannerOptions.RESULT_FORMAT_PDF
-            )
-            .setScannerMode(GmsDocumentScannerOptions.SCANNER_MODE_FULL)
-            .build()
+    private fun startDocumentScanUri(page: Int = 5) {
+        val options =
+            GmsDocumentScannerOptions.Builder().setGalleryImportAllowed(true).setPageLimit(page)
+                .setResultFormats(
+                    GmsDocumentScannerOptions.RESULT_FORMAT_JPEG,
+                    GmsDocumentScannerOptions.RESULT_FORMAT_PDF
+                ).setScannerMode(GmsDocumentScannerOptions.SCANNER_MODE_FULL).build()
         val scanner = GmsDocumentScanning.getClient(options)
         val task: Task<IntentSender>? = activity?.let { scanner.getStartScanIntent(it) }
         task?.addOnSuccessListener { intentSender ->

--- a/example/lib/main.dart
+++ b/example/lib/main.dart
@@ -23,7 +23,7 @@ class _MyAppState extends State<MyApp> {
   Future<void> scanDocument() async {
     dynamic scannedDocuments;
     try {
-      scannedDocuments = await FlutterDocScanner().getScanDocuments() ??
+      scannedDocuments = await FlutterDocScanner().getScanDocuments(5) ??
           'Unknown platform documents';
     } on PlatformException {
       scannedDocuments = 'Failed to get scanned documents.';
@@ -38,7 +38,7 @@ class _MyAppState extends State<MyApp> {
   Future<void> scanDocumentUri() async {
     dynamic scannedDocuments;
     try {
-      scannedDocuments = await FlutterDocScanner().getScanDocumentsUri() ??
+      scannedDocuments = await FlutterDocScanner().getScanDocumentsUri(5) ??
           'Unknown platform documents';
     } on PlatformException {
       scannedDocuments = 'Failed to get scanned documents.';

--- a/lib/flutter_doc_scanner.dart
+++ b/lib/flutter_doc_scanner.dart
@@ -6,13 +6,13 @@ class FlutterDocScanner {
     return FlutterDocScannerPlatform.instance.getPlatformVersion();
   }
 
-  Future<dynamic> getScanDocuments() {
-    return FlutterDocScannerPlatform.instance.getScanDocuments();
+  Future<dynamic> getScanDocuments([int page = 5]) {
+    return FlutterDocScannerPlatform.instance.getScanDocuments(page);
   }
 
-  Future<dynamic> getScanDocumentsUri() {
+  Future<dynamic> getScanDocumentsUri([int page = 5]) {
     if (defaultTargetPlatform == TargetPlatform.android) {
-      return FlutterDocScannerPlatform.instance.getScanDocumentsUri();
+      return FlutterDocScannerPlatform.instance.getScanDocumentsUri(page);
     } else {
       return Future.error(
           "Currently, this feature is supported only on Android Platform");

--- a/lib/flutter_doc_scanner_method_channel.dart
+++ b/lib/flutter_doc_scanner_method_channel.dart
@@ -17,15 +17,20 @@ class MethodChannelFlutterDocScanner extends FlutterDocScannerPlatform {
   }
 
   @override
-  Future<dynamic> getScanDocuments() async {
-    final data = await methodChannel.invokeMethod<dynamic>('getScanDocuments');
+  Future<dynamic> getScanDocuments([int page = 1]) async {
+    final data = await methodChannel.invokeMethod<dynamic>(
+      'getScanDocuments',
+      {'page': page},
+    );
     return data;
   }
 
   @override
-  Future<dynamic> getScanDocumentsUri() async {
-    final data =
-        await methodChannel.invokeMethod<dynamic>('getScanDocumentsUri');
+  Future<dynamic> getScanDocumentsUri([int page = 1]) async {
+    final data = await methodChannel.invokeMethod<dynamic>(
+      'getScanDocumentsUri',
+      {'page': page},
+    );
     return data;
   }
 }

--- a/lib/flutter_doc_scanner_platform_interface.dart
+++ b/lib/flutter_doc_scanner_platform_interface.dart
@@ -27,11 +27,11 @@ abstract class FlutterDocScannerPlatform extends PlatformInterface {
     throw UnimplementedError('platformVersion() has not been implemented.');
   }
 
-  Future<dynamic> getScanDocuments() {
+  Future<dynamic> getScanDocuments([int page = 5]) {
     throw UnimplementedError('ScanDocuments() has not been implemented.');
   }
 
-  Future<dynamic> getScanDocumentsUri() {
+  Future<dynamic> getScanDocumentsUri([int page = 5]) {
     throw UnimplementedError('ScanDocuments() has not been implemented.');
   }
 }

--- a/lib/flutter_doc_scanner_web.dart
+++ b/lib/flutter_doc_scanner_web.dart
@@ -25,13 +25,13 @@ class FlutterDocScannerWeb extends FlutterDocScannerPlatform {
   }
 
   @override
-  Future<String?> getScanDocuments() async {
+  Future<String?> getScanDocuments([int page = 5]) async {
     final data = html.window.navigator.userAgent;
     return data;
   }
 
   @override
-  Future<String?> getScanDocumentsUri() async {
+  Future<String?> getScanDocumentsUri([int page = 5]) async {
     final data = html.window.navigator.userAgent;
     return data;
   }

--- a/test/flutter_doc_scanner_test.dart
+++ b/test/flutter_doc_scanner_test.dart
@@ -11,10 +11,10 @@ class MockFlutterDocScannerPlatform
   Future<String?> getPlatformVersion() => Future.value('42');
 
   @override
-  Future<String?> getScanDocuments() => Future.value();
+  Future<String?> getScanDocuments([int page = 5]) => Future.value();
 
   @override
-  Future<String?> getScanDocumentsUri() => Future.value();
+  Future<String?> getScanDocumentsUri([int page = 5]) => Future.value();
 }
 
 void main() {


### PR DESCRIPTION
Implemented functionality to set scan page limit. To set limit `page` int parameter can be passed in method getScanDocumentsUri(1) and  getScanDocuments(5). 
It fixed the open issue #15 and #31
Set Default page limit as 5, earlier it was 9.