### PR TITLE
Add useAutomaticSinglePictureProcessing mode for fast single-document…

### DIFF
--- a/android/src/main/kotlin/com/shirsh/flutter_doc_scanner/FlutterDocScannerPlugin.kt
+++ b/android/src/main/kotlin/com/shirsh/flutter_doc_scanner/FlutterDocScannerPlugin.kt
@@ -86,20 +86,42 @@ class FlutterDocScannerPlugin : MethodCallHandler, ActivityResultListener,
         }
 
         val pageLimit = (arguments?.get("page") as? Int)?.coerceAtLeast(1) ?: DEFAULT_PAGE_LIMIT
+        val useAutomaticSinglePictureProcessing =
+            (arguments?.get("useAutomaticSinglePictureProcessing") as? Boolean) ?: false
+        // New fast path: single page + base scanner mode (page argument is intentionally ignored).
+        val fastSinglePageMode =
+            requestCode == REQUEST_CODE_SCAN_IMAGES && useAutomaticSinglePictureProcessing
+        val effectivePageLimit = if (fastSinglePageMode) 1 else pageLimit
+        val scannerMode = if (fastSinglePageMode) {
+            GmsDocumentScannerOptions.SCANNER_MODE_BASE
+        } else {
+            GmsDocumentScannerOptions.SCANNER_MODE_FULL
+        }
+        val galleryImportAllowed = !fastSinglePageMode
+
         pendingResult = result
-        launchDocumentScanner(currentActivity, pageLimit, requestCode, resultFormats)
+        launchDocumentScanner(
+            currentActivity,
+            effectivePageLimit,
+            requestCode,
+            resultFormats,
+            scannerMode,
+            galleryImportAllowed
+        )
     }
 
     private fun launchDocumentScanner(
         currentActivity: Activity,
         pageLimit: Int,
         requestCode: Int,
-        resultFormats: IntArray
+        resultFormats: IntArray,
+        scannerMode: Int,
+        galleryImportAllowed: Boolean
     ) {
         val options = GmsDocumentScannerOptions.Builder()
-            .setGalleryImportAllowed(true)
+            .setGalleryImportAllowed(galleryImportAllowed)
             .setPageLimit(pageLimit)
-            .setScannerMode(GmsDocumentScannerOptions.SCANNER_MODE_FULL)
+            .setScannerMode(scannerMode)
         if (resultFormats.isNotEmpty()) {
             val firstFormat = resultFormats.first()
             val remainingFormats = resultFormats.drop(1).toIntArray()
@@ -175,8 +197,9 @@ class FlutterDocScannerPlugin : MethodCallHandler, ActivityResultListener,
         when (resultCode) {
             Activity.RESULT_OK -> {
                 val pages = GmsDocumentScanningResult.fromActivityResultIntent(data)?.getPages()
-                val imageUris =
-                    pages?.mapNotNull { page -> page.getImageUri()?.toString() } ?: emptyList()
+                val imageUris = pages
+                    ?.mapNotNull { page -> page.getImageUri()?.toString() }
+                    ?: emptyList()
                 if (imageUris.isNotEmpty()) {
                     finishWithSuccess(
                         mapOf(

--- a/ios/Classes/AutoScanViewController.swift
+++ b/ios/Classes/AutoScanViewController.swift
@@ -1,0 +1,392 @@
+import AVFoundation
+import UIKit
+import Vision
+import CoreImage
+
+@available(iOS 13.0, *)
+// Custom single-picture scanner used by getScannedDocumentAsImages when
+// useAutomaticSinglePictureProcessing is enabled.
+final class AutoScanViewController: UIViewController, AVCapturePhotoCaptureDelegate {
+    enum ScannerError: LocalizedError {
+        case cameraUnavailable
+        case cameraInputUnavailable
+        case cameraPermissionDenied
+        case imageEncodingFailed
+
+        var errorDescription: String? {
+            switch self {
+            case .cameraUnavailable:
+                return "Back camera is unavailable on this device."
+            case .cameraInputUnavailable:
+                return "Unable to configure camera input or output."
+            case .cameraPermissionDenied:
+                return "Camera permission was denied."
+            case .imageEncodingFailed:
+                return "Unable to create image data from camera capture."
+            }
+        }
+    }
+
+    var onImageCaptured: ((UIImage) -> Void)?
+    var onCancel: (() -> Void)?
+    var onError: ((Error) -> Void)?
+
+    private let captureSession = AVCaptureSession()
+    private let sessionQueue = DispatchQueue(label: "com.flutter_doc_scanner.autoscan.session")
+    private let processingQueue = DispatchQueue(label: "com.flutter_doc_scanner.autoscan.processing")
+    private let photoOutput = AVCapturePhotoOutput()
+    private let ciContext = CIContext()
+
+    private var previewLayer: AVCaptureVideoPreviewLayer?
+    private var hasConfiguredSession = false
+    private var isCapturingPhoto = false
+
+    private lazy var cancelButton: UIButton = {
+        let button = UIButton(type: .system)
+        button.setTitle("Cancel", for: .normal)
+        button.tintColor = .white
+        button.backgroundColor = UIColor.black.withAlphaComponent(0.35)
+        button.titleLabel?.font = UIFont.systemFont(ofSize: 16, weight: .semibold)
+        button.layer.cornerRadius = 18
+        button.contentEdgeInsets = UIEdgeInsets(top: 8, left: 14, bottom: 8, right: 14)
+        button.addTarget(self, action: #selector(cancelTapped), for: .touchUpInside)
+        button.translatesAutoresizingMaskIntoConstraints = false
+        return button
+    }()
+
+    private lazy var captureButton: UIButton = {
+        let button = UIButton(type: .custom)
+        button.backgroundColor = .white
+        button.layer.cornerRadius = 34
+        button.layer.borderWidth = 4
+        button.layer.borderColor = UIColor.black.withAlphaComponent(0.20).cgColor
+        button.addTarget(self, action: #selector(captureTapped), for: .touchDown)
+        button.translatesAutoresizingMaskIntoConstraints = false
+        return button
+    }()
+
+    override var supportedInterfaceOrientations: UIInterfaceOrientationMask {
+        .portrait
+    }
+
+    override var preferredInterfaceOrientationForPresentation: UIInterfaceOrientation {
+        .portrait
+    }
+
+    override var shouldAutorotate: Bool {
+        false
+    }
+
+    override func viewDidLoad() {
+        super.viewDidLoad()
+        view.backgroundColor = .black
+
+        view.addSubview(cancelButton)
+        view.addSubview(captureButton)
+
+        NSLayoutConstraint.activate([
+            cancelButton.topAnchor.constraint(equalTo: view.safeAreaLayoutGuide.topAnchor, constant: 12),
+            cancelButton.leadingAnchor.constraint(equalTo: view.leadingAnchor, constant: 12),
+            captureButton.centerXAnchor.constraint(equalTo: view.centerXAnchor),
+            captureButton.bottomAnchor.constraint(equalTo: view.safeAreaLayoutGuide.bottomAnchor, constant: -24),
+            captureButton.widthAnchor.constraint(equalToConstant: 68),
+            captureButton.heightAnchor.constraint(equalToConstant: 68)
+        ])
+    }
+
+    override func viewDidLayoutSubviews() {
+        super.viewDidLayoutSubviews()
+        previewLayer?.frame = view.bounds
+        if let previewConnection = previewLayer?.connection,
+           previewConnection.isVideoOrientationSupported {
+            previewConnection.videoOrientation = .portrait
+        }
+    }
+
+    override func viewDidAppear(_ animated: Bool) {
+        super.viewDidAppear(animated)
+        startScannerIfNeeded()
+    }
+
+    override func viewWillDisappear(_ animated: Bool) {
+        super.viewWillDisappear(animated)
+        stopSession()
+    }
+
+    @objc
+    private func cancelTapped() {
+        dismissScanner { [weak self] in
+            self?.onCancel?()
+        }
+    }
+
+    @objc
+    private func captureTapped() {
+        guard !isCapturingPhoto else { return }
+        isCapturingPhoto = true
+        captureButton.isEnabled = false
+        cancelButton.isEnabled = false
+        freezePreviewImmediately()
+        capturePhoto()
+    }
+
+    private func startScannerIfNeeded() {
+        switch AVCaptureDevice.authorizationStatus(for: .video) {
+        case .authorized:
+            configureAndStartSession()
+        case .notDetermined:
+            AVCaptureDevice.requestAccess(for: .video) { [weak self] granted in
+                DispatchQueue.main.async {
+                    guard let self = self else { return }
+                    if granted {
+                        self.configureAndStartSession()
+                    } else {
+                        self.failAndDismiss(ScannerError.cameraPermissionDenied)
+                    }
+                }
+            }
+        default:
+            failAndDismiss(ScannerError.cameraPermissionDenied)
+        }
+    }
+
+    private func configureAndStartSession() {
+        if hasConfiguredSession {
+            startSession()
+            return
+        }
+
+        sessionQueue.async { [weak self] in
+            guard let self = self else { return }
+            do {
+                try self.configureCaptureSession()
+                self.hasConfiguredSession = true
+                self.captureSession.startRunning()
+            } catch {
+                DispatchQueue.main.async {
+                    self.failAndDismiss(error)
+                }
+            }
+        }
+    }
+
+    private func configureCaptureSession() throws {
+        captureSession.beginConfiguration()
+        captureSession.sessionPreset = .high
+        defer { captureSession.commitConfiguration() }
+
+        guard let camera = AVCaptureDevice.default(.builtInWideAngleCamera, for: .video, position: .back) else {
+            throw ScannerError.cameraUnavailable
+        }
+
+        let input = try AVCaptureDeviceInput(device: camera)
+        guard captureSession.canAddInput(input) else {
+            throw ScannerError.cameraInputUnavailable
+        }
+        captureSession.addInput(input)
+
+        guard captureSession.canAddOutput(photoOutput) else {
+            throw ScannerError.cameraInputUnavailable
+        }
+        captureSession.addOutput(photoOutput)
+        photoOutput.isHighResolutionCaptureEnabled = false
+
+        if let photoConnection = photoOutput.connection(with: .video),
+           photoConnection.isVideoOrientationSupported {
+            photoConnection.videoOrientation = .portrait
+        }
+
+        DispatchQueue.main.async { [weak self] in
+            guard let self = self else { return }
+            let preview = AVCaptureVideoPreviewLayer(session: self.captureSession)
+            preview.videoGravity = .resizeAspectFill
+            preview.frame = self.view.bounds
+            self.view.layer.insertSublayer(preview, at: 0)
+            self.previewLayer = preview
+        }
+    }
+
+    private func startSession() {
+        sessionQueue.async { [weak self] in
+            guard let self = self else { return }
+            if !self.captureSession.isRunning {
+                self.captureSession.startRunning()
+            }
+        }
+    }
+
+    private func stopSession() {
+        sessionQueue.async { [weak self] in
+            guard let self = self else { return }
+            if self.captureSession.isRunning {
+                self.captureSession.stopRunning()
+            }
+        }
+    }
+
+    private func dismissScanner(animated: Bool = true, completion: @escaping () -> Void) {
+        stopSession()
+        dismiss(animated: animated, completion: completion)
+    }
+
+    private func failAndDismiss(_ error: Error) {
+        dismissScanner { [weak self] in
+            self?.onError?(error)
+        }
+    }
+
+    private func capturePhoto() {
+        let settings: AVCapturePhotoSettings
+        if photoOutput.availablePhotoCodecTypes.contains(.jpeg) {
+            settings = AVCapturePhotoSettings(format: [AVVideoCodecKey: AVVideoCodecType.jpeg])
+        } else {
+            settings = AVCapturePhotoSettings()
+        }
+        settings.isHighResolutionPhotoEnabled = false
+        settings.photoQualityPrioritization = .speed
+
+        if let connection = photoOutput.connection(with: .video),
+           connection.isVideoOrientationSupported {
+            connection.videoOrientation = .portrait
+        }
+
+        photoOutput.capturePhoto(with: settings, delegate: self)
+    }
+
+    func photoOutput(
+        _ output: AVCapturePhotoOutput,
+        didFinishProcessingPhoto photo: AVCapturePhoto,
+        error: Error?
+    ) {
+        if let error = error {
+            failAndDismiss(error)
+            return
+        }
+
+        guard let imageData = photo.fileDataRepresentation(),
+              let image = UIImage(data: imageData) else {
+            failAndDismiss(ScannerError.imageEncodingFailed)
+            return
+        }
+
+        dismissScanner(animated: false) { [self] in
+            processAndDeliverCapturedImage(image)
+        }
+    }
+
+    private func processAndDeliverCapturedImage(_ image: UIImage) {
+        processingQueue.async { [self] in
+            let processedImage = prepareSingleImage(image, maxDimension: 1280)
+            DispatchQueue.main.async {
+                self.onImageCaptured?(processedImage)
+            }
+        }
+    }
+
+    private func prepareSingleImage(_ image: UIImage, maxDimension: CGFloat) -> UIImage {
+        let normalizedImage = normalizedUprightImage(image)
+        // Keep detection fast by limiting input size.
+        let detectionInput = resizedImageIfNeeded(normalizedImage, maxDimension: 1600)
+        let croppedImage = detectAndCropDocument(detectionInput) ?? detectionInput
+        let portraitImage = forcePortraitOrientation(croppedImage)
+        return resizedImageIfNeeded(portraitImage, maxDimension: maxDimension)
+    }
+
+    private func normalizedUprightImage(_ image: UIImage) -> UIImage {
+        if image.imageOrientation == .up {
+            return image
+        }
+
+        let renderer = UIGraphicsImageRenderer(size: image.size)
+        return renderer.image { _ in
+            image.draw(in: CGRect(origin: .zero, size: image.size))
+        }
+    }
+
+    private func forcePortraitOrientation(_ image: UIImage) -> UIImage {
+        guard image.size.width > image.size.height else {
+            return image
+        }
+
+        let targetSize = CGSize(width: image.size.height, height: image.size.width)
+        let renderer = UIGraphicsImageRenderer(size: targetSize)
+        return renderer.image { _ in
+            let context = UIGraphicsGetCurrentContext()
+            context?.translateBy(x: targetSize.width / 2, y: targetSize.height / 2)
+            context?.rotate(by: -.pi / 2)
+            image.draw(
+                in: CGRect(
+                    x: -image.size.width / 2,
+                    y: -image.size.height / 2,
+                    width: image.size.width,
+                    height: image.size.height
+                )
+            )
+        }
+    }
+
+    private func resizedImageIfNeeded(_ image: UIImage, maxDimension: CGFloat) -> UIImage {
+        let currentMax = max(image.size.width, image.size.height)
+        guard currentMax > maxDimension else { return image }
+
+        let scale = maxDimension / currentMax
+        let targetSize = CGSize(width: image.size.width * scale, height: image.size.height * scale)
+        let renderer = UIGraphicsImageRenderer(size: targetSize)
+        return renderer.image { _ in
+            image.draw(in: CGRect(origin: .zero, size: targetSize))
+        }
+    }
+
+    private func detectAndCropDocument(_ image: UIImage) -> UIImage? {
+        guard let cgImage = image.cgImage else { return nil }
+        let ciImage = CIImage(cgImage: cgImage)
+
+        let request = VNDetectRectanglesRequest()
+        request.maximumObservations = 1
+        request.minimumConfidence = 0.7
+        request.minimumSize = 0.2
+        request.minimumAspectRatio = 0.3
+        request.quadratureTolerance = 20.0
+
+        let handler = VNImageRequestHandler(ciImage: ciImage, options: [:])
+        do {
+            try handler.perform([request])
+        } catch {
+            return nil
+        }
+
+        guard let observation = (request.results as? [VNRectangleObservation])?.first else {
+            return nil
+        }
+
+        let extent = ciImage.extent
+        func denormalize(_ point: CGPoint) -> CGPoint {
+            CGPoint(
+                x: extent.origin.x + point.x * extent.width,
+                y: extent.origin.y + point.y * extent.height
+            )
+        }
+
+        guard let perspectiveFilter = CIFilter(name: "CIPerspectiveCorrection") else {
+            return nil
+        }
+        perspectiveFilter.setValue(ciImage, forKey: kCIInputImageKey)
+        perspectiveFilter.setValue(CIVector(cgPoint: denormalize(observation.topLeft)), forKey: "inputTopLeft")
+        perspectiveFilter.setValue(CIVector(cgPoint: denormalize(observation.topRight)), forKey: "inputTopRight")
+        perspectiveFilter.setValue(CIVector(cgPoint: denormalize(observation.bottomRight)), forKey: "inputBottomRight")
+        perspectiveFilter.setValue(CIVector(cgPoint: denormalize(observation.bottomLeft)), forKey: "inputBottomLeft")
+
+        guard let outputImage = perspectiveFilter.outputImage,
+              let outputCGImage = ciContext.createCGImage(outputImage, from: outputImage.extent) else {
+            return nil
+        }
+
+        return UIImage(cgImage: outputCGImage)
+    }
+
+    private func freezePreviewImmediately() {
+        if let previewConnection = previewLayer?.connection {
+            previewConnection.isEnabled = false
+        }
+    }
+}

--- a/ios/Classes/SwiftFlutterDocScannerPlugin.swift
+++ b/ios/Classes/SwiftFlutterDocScannerPlugin.swift
@@ -28,9 +28,41 @@ public class SwiftFlutterDocScannerPlugin: NSObject, FlutterPlugin, VNDocumentCa
            let presentedVC: UIViewController? = UIApplication.shared.keyWindow?.rootViewController
            self.resultChannel = result
            self.currentMethod = call.method
-           self.presentingController = VNDocumentCameraViewController()
-           self.presentingController!.delegate = self
-           presentedVC?.present(self.presentingController!, animated: true)
+           let arguments = call.arguments as? [String: Any]
+           let useAutomaticSinglePictureProcessing =
+               (arguments?["useAutomaticSinglePictureProcessing"] as? Bool) ?? false
+
+           if useAutomaticSinglePictureProcessing {
+               // New fast path: capture one picture and return immediately without review UI.
+               let controller = AutoScanViewController()
+               controller.modalPresentationStyle = .fullScreen
+               controller.onImageCaptured = { [weak self] image in
+                   guard let self = self else { return }
+                   DispatchQueue.global(qos: .userInitiated).async {
+                       do {
+                           let path = try self.saveSingleImage(image: image)
+                           DispatchQueue.main.async {
+                               self.resultChannel?([path])
+                           }
+                       } catch {
+                           DispatchQueue.main.async {
+                               self.resultChannel?(FlutterError(code: "SCAN_SAVE_ERROR", message: "Failed to save captured image", details: error.localizedDescription))
+                           }
+                       }
+                   }
+               }
+               controller.onCancel = { [weak self] in
+                   self?.resultChannel?(nil)
+               }
+               controller.onError = { [weak self] error in
+                   self?.resultChannel?(FlutterError(code: "SCAN_ERROR", message: "Failed to scan documents", details: error.localizedDescription))
+               }
+               presentedVC?.present(controller, animated: true)
+           } else {
+               self.presentingController = VNDocumentCameraViewController()
+               self.presentingController!.delegate = self
+               presentedVC?.present(self.presentingController!, animated: true)
+           }
        } else if call.method == "getScannedDocumentAsPdf" {
            let presentedVC: UIViewController? = UIApplication.shared.keyWindow?.rootViewController
            self.resultChannel = result
@@ -48,6 +80,20 @@ public class SwiftFlutterDocScannerPlugin: NSObject, FlutterPlugin, VNDocumentCa
        let paths = FileManager.default.urls(for: .documentDirectory, in: .userDomainMask)
        let documentsDirectory = paths[0]
        return documentsDirectory
+   }
+
+   private func saveSingleImage(image: UIImage) throws -> String {
+       let tempDirPath = getDocumentsDirectory()
+       let currentDateTime = Date()
+       let df = DateFormatter()
+       df.dateFormat = "yyyyMMdd-HHmmss"
+       let formattedDate = df.string(from: currentDateTime)
+       let imagePath = tempDirPath.appendingPathComponent(formattedDate + "-0.jpg")
+       guard let data = image.jpegData(compressionQuality: 0.78) else {
+           throw NSError(domain: "flutter_doc_scanner", code: 1001, userInfo: [NSLocalizedDescriptionKey: "Unable to encode JPEG data."])
+       }
+       try data.write(to: imagePath, options: .atomic)
+       return imagePath.path
    }
 
    public func documentCameraViewController(_ controller: VNDocumentCameraViewController, didFinishWith scan: VNDocumentCameraScan) {

--- a/lib/flutter_doc_scanner.dart
+++ b/lib/flutter_doc_scanner.dart
@@ -10,8 +10,15 @@ class FlutterDocScanner {
     return FlutterDocScannerPlatform.instance.getScanDocuments(page);
   }
 
-  Future<dynamic> getScannedDocumentAsImages({int page = 4}) {
-    return FlutterDocScannerPlatform.instance.getScannedDocumentAsImages(page);
+  /// If [useAutomaticSinglePictureProcessing] is true, native code uses
+  /// a fast single-picture flow and ignores [page].
+  Future<dynamic> getScannedDocumentAsImages(
+      {int page = 4, bool useAutomaticSinglePictureProcessing = false}) {
+    return FlutterDocScannerPlatform.instance.getScannedDocumentAsImages(
+      page: page,
+      useAutomaticSinglePictureProcessing:
+          useAutomaticSinglePictureProcessing,
+    );
   }
 
   Future<dynamic> getScannedDocumentAsPdf({int page = 4}) {

--- a/lib/flutter_doc_scanner_method_channel.dart
+++ b/lib/flutter_doc_scanner_method_channel.dart
@@ -26,10 +26,15 @@ class MethodChannelFlutterDocScanner extends FlutterDocScannerPlatform {
   }
 
   @override
-  Future<dynamic> getScannedDocumentAsImages([int page = 4]) async {
+  Future<dynamic> getScannedDocumentAsImages(
+      {int page = 4, bool useAutomaticSinglePictureProcessing = false}) async {
     final data = await methodChannel.invokeMethod<dynamic>(
       'getScannedDocumentAsImages',
-      {'page': page},
+      {
+        'page': page,
+        'useAutomaticSinglePictureProcessing':
+            useAutomaticSinglePictureProcessing,
+      },
     );
     return data;
   }

--- a/lib/flutter_doc_scanner_platform_interface.dart
+++ b/lib/flutter_doc_scanner_platform_interface.dart
@@ -31,7 +31,10 @@ abstract class FlutterDocScannerPlatform extends PlatformInterface {
     throw UnimplementedError('getScanDocuments() has not been implemented.');
   }
 
-  Future<dynamic> getScannedDocumentAsImages([int page = 4]) {
+  /// If [useAutomaticSinglePictureProcessing] is true, native code uses
+  /// a fast single-picture flow and ignores [page].
+  Future<dynamic> getScannedDocumentAsImages(
+      {int page = 4, bool useAutomaticSinglePictureProcessing = false}) {
     throw UnimplementedError(
         'getScannedDocumentAsImages() has not been implemented.');
   }

--- a/test/flutter_doc_scanner_test.dart
+++ b/test/flutter_doc_scanner_test.dart
@@ -14,7 +14,8 @@ class MockFlutterDocScannerPlatform
   Future<String?> getScanDocuments([int page = 4]) => Future.value();
 
   @override
-  Future<String?> getScannedDocumentAsImages([int page = 4]) =>
+  Future<String?> getScannedDocumentAsImages(
+          {int page = 4, bool useAutomaticSinglePictureProcessing = false}) =>
       Future.value();
 
   @override


### PR DESCRIPTION
Hi there ! We already had a quick chat about this feature in this thread https://github.com/shirsh94/flutter_doc_scanner/issues/68#event-23289434179
I went ahead and implemented it, here is a short overview of what I did and why I did it. 
Let me know what you think, I will be here for revisions & hope we can get this into the package soon !

This PR adds a new optional flag to getScannedDocumentAsImages:

useAutomaticSinglePictureProcessing (default: false)
When enabled, the scanner uses a fast single-picture flow intended for the “one receipt per scan” use case.
When disabled, existing behavior remains unchanged.

What changed
Dart API
Added useAutomaticSinglePictureProcessing to:
flutter_doc_scanner.dart
flutter_doc_scanner_platform_interface.dart
flutter_doc_scanner_method_channel.dart
Updated tests for the new method signature.
iOS
Added a dedicated fast-flow controller: AutoScanViewController.swift.
In SwiftFlutterDocScannerPlugin, getScannedDocumentAsImages now branches:
false -> existing VNDocumentCameraViewController flow (unchanged)
true -> single-picture automatic flow via AutoScanViewController
Android
Kept GMS scanner implementation (no custom camera pipeline in package).
In FlutterDocScannerPlugin, when useAutomaticSinglePictureProcessing == true for image scan:
force single page (pageLimit = 1)
use SCANNER_MODE_BASE for shortest available GMS UI flow
ignore page argument intentionally
false keeps existing full flow behavior.
Why these decisions
Backward compatibility / minimal risk

Default remains false, so existing consumers keep current behavior.
Old flow is preserved as-is on both platforms.
Platform-appropriate implementation

iOS: custom automatic single-shot flow is feasible with native camera/vision stack.
Android: GMS Document Scanner is intentionally UI-driven; there is no public API to bypass its internal steps completely.
Therefore, this PR uses the fastest supported GMS configuration instead of replacing scanner internals.
Reviewability

Changes are scoped to the existing scanner entry points and one new iOS controller file.
No unrelated dependency or build-system refactors included.
Behavior matrix
useAutomaticSinglePictureProcessing: false
-> current scanner behavior (existing UX)

useAutomaticSinglePictureProcessing: true
-> optimized single-picture flow (iOS custom fast flow, Android fastest GMS mode), page ignored