### PR TITLE
Add fast single-picture scanning mode via useAutomaticSinglePictureProcessing for quick document capture

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 0.0.19
+- Added `useAutomaticSinglePictureProcessing` flag to enable a fast single-picture scanning mode optimized for quick one-document captures.
+- Implemented platform-specific optimizations (iOS custom auto-scan flow, Android fastest GMS mode) while preserving existing behavior by default.
+
 ## 0.0.18
 -Added typed models, structured errors, image format/quality control (iOS), validation, permission checks, tests, and dependency cleanup.
 -Fixed Android 15 crashes, lifecycle/thread issues, memory leaks, file/PDF failures, deprecated APIs, and major production bugs.

--- a/README.md
+++ b/README.md
@@ -28,6 +28,7 @@ Check out the `example` directory for a sample Flutter app using `flutter_doc_sc
 - Support for sending digitized files in PDF and JPEG formats back to your app.
 - Ability to set a scan page limit.
 - Support for image(png,jpeg) format and PDF has been added through various methods.
+- Fast single-picture scanning mode via `useAutomaticSinglePictureProcessing` for quick one-document captures.
 
 
 ## Installation

--- a/README.md
+++ b/README.md
@@ -39,7 +39,7 @@ To use this plugin, add `flutter_doc_scanner` as a dependency in your `pubspec.y
 dependencies:
   flutter:
     sdk: flutter
-  flutter_doc_scanner: ^0.0.18
+  flutter_doc_scanner: ^0.0.19
 
 ```
 Got it! Here's a more detailed explanation:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: flutter_doc_scanner
 description: "A Flutter plugin for document scanning on Android and iOS using ML Kit Document Scanner API and VisionKit."
-version: 0.0.18
+version: 0.0.19
 homepage: https://github.com/shirsh94/flutter_doc_scanner/
 
 environment:


### PR DESCRIPTION
This PR introduces a new optional flag, useAutomaticSinglePictureProcessing, designed to optimize the scanning experience for quick, single-document captures.

✨ What’s new
Added useAutomaticSinglePictureProcessing (default: false)
Enables a faster scanning flow by automatically processing a single picture
Ideal for use cases where only one document/page needs to be captured
🚀 Why

The existing scanning flow is optimized for multi-page documents, which can feel slow or unnecessary for single captures. This enhancement provides a lightweight and faster alternative, improving user experience in quick-scan scenarios.

🔧 Usage

Set useAutomaticSinglePictureProcessing: true when calling the scanner to enable this mode.

📌 Notes
Fully backward compatible (disabled by default)
No impact on existing multi-page scanning behavior