### PR TITLE
fix: restore typed models (ImageScanResult, PdfScanResult, DocScanException) removed in 0.0.19

### DIFF
--- a/lib/flutter_doc_scanner.dart
+++ b/lib/flutter_doc_scanner.dart
@@ -1,36 +1,102 @@
 import 'package:flutter/foundation.dart';
+
+import 'flutter_doc_scanner_exception.dart';
+import 'flutter_doc_scanner_models.dart';
 import 'flutter_doc_scanner_platform_interface.dart';
+
+export 'flutter_doc_scanner_exception.dart';
+export 'flutter_doc_scanner_models.dart';
 
 class FlutterDocScanner {
   Future<String?> getPlatformVersion() {
     return FlutterDocScannerPlatform.instance.getPlatformVersion();
   }
 
+  /// Scans documents using the default behavior (images on iOS, PDF on Android).
+  ///
+  /// [page] is the maximum number of pages to scan (must be >= 1, defaults to 4).
+  /// Returns `null` if the user cancelled the scan.
+  /// Throws [DocScanException] on failure.
   Future<dynamic> getScanDocuments({int page = 4}) {
+    _validatePage(page);
     return FlutterDocScannerPlatform.instance.getScanDocuments(page);
   }
 
+  /// Scans documents and returns image file paths.
+  ///
+  /// [page] is the maximum number of pages to scan (must be >= 1, defaults to 4).
+  /// [imageFormat] controls the output image format. On iOS, this determines
+  /// whether images are saved as PNG or JPEG. On Android, ML Kit always returns
+  /// JPEG regardless of this setting. Defaults to [ImageFormat.jpeg].
+  /// [quality] controls JPEG compression quality on iOS (0.0 to 1.0, where 1.0
+  /// is highest quality). Only applies when [imageFormat] is [ImageFormat.jpeg].
+  /// Ignored on Android. Defaults to 0.9.
   /// If [useAutomaticSinglePictureProcessing] is true, native code uses
   /// a fast single-picture flow and ignores [page].
-  Future<dynamic> getScannedDocumentAsImages(
-      {int page = 4, bool useAutomaticSinglePictureProcessing = false}) {
-    return FlutterDocScannerPlatform.instance.getScannedDocumentAsImages(
-      page: page,
-      useAutomaticSinglePictureProcessing:
-          useAutomaticSinglePictureProcessing,
+  /// Returns `null` if the user cancelled the scan.
+  /// Throws [DocScanException] on failure.
+  Future<ImageScanResult?> getScannedDocumentAsImages({
+    int page = 4,
+    ImageFormat imageFormat = ImageFormat.jpeg,
+    double quality = 0.9,
+    bool useAutomaticSinglePictureProcessing = false,
+  }) async {
+    _validatePage(page);
+    if (quality < 0.0 || quality > 1.0) {
+      throw ArgumentError.value(
+        quality,
+        'quality',
+        'Must be between 0.0 and 1.0',
+      );
+    }
+    final data = await FlutterDocScannerPlatform.instance
+        .getScannedDocumentAsImages(
+          page: page,
+          imageFormat: imageFormat.name,
+          quality: quality,
+          useAutomaticSinglePictureProcessing:
+              useAutomaticSinglePictureProcessing,
+        );
+    if (data == null) return null;
+    return ImageScanResult.fromPlatformData(data);
+  }
+
+  /// Scans documents and returns a PDF file path.
+  ///
+  /// [page] is the maximum number of pages to scan (must be >= 1, defaults to 4).
+  /// Returns `null` if the user cancelled the scan.
+  /// Throws [DocScanException] on failure.
+  Future<PdfScanResult?> getScannedDocumentAsPdf({int page = 4}) async {
+    _validatePage(page);
+    final data = await FlutterDocScannerPlatform.instance
+        .getScannedDocumentAsPdf(page);
+    if (data == null) return null;
+    return PdfScanResult.fromPlatformData(data);
+  }
+
+  /// Scans documents and returns URIs. **Android only.**
+  ///
+  /// [page] is the maximum number of pages to scan (must be >= 1, defaults to 4).
+  /// Returns `null` if the user cancelled the scan.
+  /// Throws [DocScanException] on failure or if called on a non-Android platform.
+  Future<ImageScanResult?> getScanDocumentsUri({int page = 4}) async {
+    _validatePage(page);
+    if (defaultTargetPlatform != TargetPlatform.android) {
+      throw const DocScanException(
+        code: DocScanException.codeUnsupported,
+        message: 'getScanDocumentsUri is only supported on Android',
+      );
+    }
+    final data = await FlutterDocScannerPlatform.instance.getScanDocumentsUri(
+      page,
     );
+    if (data == null) return null;
+    return ImageScanResult.fromPlatformData(data);
   }
 
-  Future<dynamic> getScannedDocumentAsPdf({int page = 4}) {
-    return FlutterDocScannerPlatform.instance.getScannedDocumentAsPdf(page);
-  }
-
-  Future<dynamic> getScanDocumentsUri({int page = 4}) {
-    if (defaultTargetPlatform == TargetPlatform.android) {
-      return FlutterDocScannerPlatform.instance.getScanDocumentsUri(page);
-    } else {
-      return Future.error(
-          "Currently, this feature is supported only on Android Platform");
+  void _validatePage(int page) {
+    if (page < 1) {
+      throw ArgumentError.value(page, 'page', 'Must be at least 1');
     }
   }
 }

--- a/lib/flutter_doc_scanner_exception.dart
+++ b/lib/flutter_doc_scanner_exception.dart
@@ -1,0 +1,38 @@
+/// Exception thrown by the FlutterDocScanner plugin.
+class DocScanException implements Exception {
+  /// Machine-readable error code.
+  final String code;
+
+  /// Human-readable description of the error.
+  final String message;
+
+  /// Optional platform-specific details.
+  final dynamic details;
+
+  const DocScanException({
+    required this.code,
+    required this.message,
+    this.details,
+  });
+
+  /// The scanner requires a foreground activity (Android).
+  static const codeNoActivity = 'NO_ACTIVITY';
+
+  /// Another scan is already in progress.
+  static const codeScanInProgress = 'SCAN_IN_PROGRESS';
+
+  /// The scan operation failed.
+  static const codeScanFailed = 'SCAN_FAILED';
+
+  /// PDF creation failed (iOS).
+  static const codePdfCreationError = 'PDF_CREATION_ERROR';
+
+  /// The user cancelled the scan.
+  static const codeCancelled = 'CANCELLED';
+
+  /// The platform does not support this feature.
+  static const codeUnsupported = 'UNSUPPORTED_PLATFORM';
+
+  @override
+  String toString() => 'DocScanException($code): $message';
+}

--- a/lib/flutter_doc_scanner_method_channel.dart
+++ b/lib/flutter_doc_scanner_method_channel.dart
@@ -1,6 +1,7 @@
 import 'package:flutter/foundation.dart';
 import 'package:flutter/services.dart';
 
+import 'flutter_doc_scanner_exception.dart';
 import 'flutter_doc_scanner_platform_interface.dart';
 
 /// An implementation of [FlutterDocScannerPlatform] that uses method channels.
@@ -11,49 +12,80 @@ class MethodChannelFlutterDocScanner extends FlutterDocScannerPlatform {
 
   @override
   Future<String?> getPlatformVersion() async {
-    final version =
-        await methodChannel.invokeMethod<String>('getPlatformVersion');
+    final version = await methodChannel.invokeMethod<String>(
+      'getPlatformVersion',
+    );
     return version;
   }
 
   @override
-  Future<dynamic> getScanDocuments([int page = 4]) async {
-    final data = await methodChannel.invokeMethod<dynamic>(
-      'getScanDocuments',
-      {'page': page},
-    );
-    return data;
-  }
-
-  @override
-  Future<dynamic> getScannedDocumentAsImages(
-      {int page = 4, bool useAutomaticSinglePictureProcessing = false}) async {
-    final data = await methodChannel.invokeMethod<dynamic>(
-      'getScannedDocumentAsImages',
-      {
+  Future<dynamic> getScanDocuments(int page) async {
+    try {
+      return await methodChannel.invokeMethod<dynamic>('getScanDocuments', {
         'page': page,
-        'useAutomaticSinglePictureProcessing':
-            useAutomaticSinglePictureProcessing,
-      },
-    );
-    return data;
+      });
+    } on PlatformException catch (e) {
+      throw DocScanException(
+        code: e.code,
+        message: e.message ?? 'Failed to scan documents',
+        details: e.details,
+      );
+    }
   }
 
   @override
-  Future<dynamic> getScannedDocumentAsPdf([int page = 4]) async {
-    final data = await methodChannel.invokeMethod<dynamic>(
-      'getScannedDocumentAsPdf',
-      {'page': page},
-    );
-    return data;
+  Future<dynamic> getScannedDocumentAsImages({
+    required int page,
+    required String imageFormat,
+    required double quality,
+    bool useAutomaticSinglePictureProcessing = false,
+  }) async {
+    try {
+      return await methodChannel
+          .invokeMethod<dynamic>('getScannedDocumentAsImages', {
+            'page': page,
+            'imageFormat': imageFormat,
+            'quality': quality,
+            'useAutomaticSinglePictureProcessing':
+                useAutomaticSinglePictureProcessing,
+          });
+    } on PlatformException catch (e) {
+      throw DocScanException(
+        code: e.code,
+        message: e.message ?? 'Failed to scan document images',
+        details: e.details,
+      );
+    }
   }
 
   @override
-  Future<dynamic> getScanDocumentsUri([int page = 4]) async {
-    final data = await methodChannel.invokeMethod<dynamic>(
-      'getScanDocumentsUri',
-      {'page': page},
-    );
-    return data;
+  Future<dynamic> getScannedDocumentAsPdf(int page) async {
+    try {
+      return await methodChannel.invokeMethod<dynamic>(
+        'getScannedDocumentAsPdf',
+        {'page': page},
+      );
+    } on PlatformException catch (e) {
+      throw DocScanException(
+        code: e.code,
+        message: e.message ?? 'Failed to scan document as PDF',
+        details: e.details,
+      );
+    }
+  }
+
+  @override
+  Future<dynamic> getScanDocumentsUri(int page) async {
+    try {
+      return await methodChannel.invokeMethod<dynamic>('getScanDocumentsUri', {
+        'page': page,
+      });
+    } on PlatformException catch (e) {
+      throw DocScanException(
+        code: e.code,
+        message: e.message ?? 'Failed to scan document URIs',
+        details: e.details,
+      );
+    }
   }
 }

--- a/lib/flutter_doc_scanner_models.dart
+++ b/lib/flutter_doc_scanner_models.dart
@@ -1,0 +1,79 @@
+/// Image format for scanned document images.
+///
+/// On Android, ML Kit always returns JPEG regardless of this setting.
+/// On iOS, this controls whether images are saved as PNG or JPEG.
+enum ImageFormat {
+  /// PNG format. Lossless, larger file size. Default on iOS.
+  png,
+
+  /// JPEG format. Lossy, smaller file size. Default on Android.
+  jpeg,
+}
+
+/// Result from scanning documents as images.
+class ImageScanResult {
+  /// List of file paths (iOS) or content URIs (Android) for the scanned images.
+  final List<String> images;
+
+  /// Number of scanned images.
+  int get count => images.length;
+
+  const ImageScanResult({required this.images});
+
+  /// Creates an [ImageScanResult] from the raw platform channel data.
+  ///
+  /// On Android, the data is a Map with 'images' key.
+  /// On iOS, the data is a List of file paths.
+  factory ImageScanResult.fromPlatformData(dynamic data) {
+    if (data is Map) {
+      final images = (data['images'] as List?)?.cast<String>() ?? [];
+      return ImageScanResult(images: images);
+    }
+    if (data is List) {
+      return ImageScanResult(images: data.cast<String>());
+    }
+    throw FormatException(
+      'Unexpected image scan result type: ${data.runtimeType}',
+    );
+  }
+
+  @override
+  String toString() => 'ImageScanResult(images: $images, count: $count)';
+}
+
+/// Result from scanning documents as a PDF.
+class PdfScanResult {
+  /// File path (iOS) or content URI (Android) of the generated PDF.
+  final String pdfUri;
+
+  /// Number of pages in the PDF. Only available on Android; defaults to 0 on iOS.
+  final int pageCount;
+
+  const PdfScanResult({required this.pdfUri, this.pageCount = 0});
+
+  /// Creates a [PdfScanResult] from the raw platform channel data.
+  ///
+  /// On Android, the data is a Map with 'pdfUri' and 'pageCount' keys.
+  /// On iOS, the data is a String file path.
+  factory PdfScanResult.fromPlatformData(dynamic data) {
+    if (data is Map) {
+      final uri = data['pdfUri'] as String?;
+      if (uri == null) {
+        throw const FormatException('Missing pdfUri in PDF scan result');
+      }
+      return PdfScanResult(
+        pdfUri: uri,
+        pageCount: (data['pageCount'] as int?) ?? 0,
+      );
+    }
+    if (data is String) {
+      return PdfScanResult(pdfUri: data);
+    }
+    throw FormatException(
+      'Unexpected PDF scan result type: ${data.runtimeType}',
+    );
+  }
+
+  @override
+  String toString() => 'PdfScanResult(pdfUri: $pdfUri, pageCount: $pageCount)';
+}

--- a/lib/flutter_doc_scanner_platform_interface.dart
+++ b/lib/flutter_doc_scanner_platform_interface.dart
@@ -27,24 +27,44 @@ abstract class FlutterDocScannerPlatform extends PlatformInterface {
     throw UnimplementedError('getPlatformVersion() has not been implemented.');
   }
 
-  Future<dynamic> getScanDocuments([int page = 4]) {
+  /// Scans documents and returns raw platform data.
+  ///
+  /// Returns `null` if the user cancelled. The raw data shape varies by
+  /// platform and is normalized by [FlutterDocScanner].
+  Future<dynamic> getScanDocuments(int page) {
     throw UnimplementedError('getScanDocuments() has not been implemented.');
   }
 
+  /// Scans documents and returns raw image data from the platform.
+  ///
+  /// [imageFormat] controls the output format on iOS (Android always returns JPEG).
   /// If [useAutomaticSinglePictureProcessing] is true, native code uses
   /// a fast single-picture flow and ignores [page].
-  Future<dynamic> getScannedDocumentAsImages(
-      {int page = 4, bool useAutomaticSinglePictureProcessing = false}) {
+  /// Returns `null` if the user cancelled.
+  Future<dynamic> getScannedDocumentAsImages({
+    required int page,
+    required String imageFormat,
+    required double quality,
+    bool useAutomaticSinglePictureProcessing = false,
+  }) {
     throw UnimplementedError(
-        'getScannedDocumentAsImages() has not been implemented.');
+      'getScannedDocumentAsImages() has not been implemented.',
+    );
   }
 
-  Future<dynamic> getScannedDocumentAsPdf([int page = 4]) {
+  /// Scans documents and returns raw PDF data from the platform.
+  ///
+  /// Returns `null` if the user cancelled.
+  Future<dynamic> getScannedDocumentAsPdf(int page) {
     throw UnimplementedError(
-        'getScannedDocumentAsPdf() has not been implemented.');
+      'getScannedDocumentAsPdf() has not been implemented.',
+    );
   }
 
-  Future<dynamic> getScanDocumentsUri([int page = 4]) {
+  /// Scans documents and returns URIs (Android only).
+  ///
+  /// Returns `null` if the user cancelled.
+  Future<dynamic> getScanDocumentsUri(int page) {
     throw UnimplementedError('getScanDocumentsUri() has not been implemented.');
   }
 }

--- a/test/flutter_doc_scanner_test.dart
+++ b/test/flutter_doc_scanner_test.dart
@@ -11,18 +11,21 @@ class MockFlutterDocScannerPlatform
   Future<String?> getPlatformVersion() => Future.value('42');
 
   @override
-  Future<String?> getScanDocuments([int page = 4]) => Future.value();
+  Future<dynamic> getScanDocuments(int page) => Future.value();
 
   @override
-  Future<String?> getScannedDocumentAsImages(
-          {int page = 4, bool useAutomaticSinglePictureProcessing = false}) =>
-      Future.value();
+  Future<dynamic> getScannedDocumentAsImages({
+    required int page,
+    required String imageFormat,
+    required double quality,
+    bool useAutomaticSinglePictureProcessing = false,
+  }) => Future.value();
 
   @override
-  Future<String?> getScannedDocumentAsPdf([int page = 4]) => Future.value();
+  Future<dynamic> getScannedDocumentAsPdf(int page) => Future.value();
 
   @override
-  Future<String?> getScanDocumentsUri([int page = 4]) => Future.value();
+  Future<dynamic> getScanDocumentsUri(int page) => Future.value();
 }
 
 void main() {


### PR DESCRIPTION
## Summary

- Restores `ImageScanResult`, `PdfScanResult`, and `DocScanException` classes that were removed in 0.0.19
- Restores typed return types (`Future<ImageScanResult?>`, `Future<PdfScanResult?>`) instead of `Future<dynamic>`
- Restores structured error handling (`DocScanException` wrapping `PlatformException`)
- Preserves the `useAutomaticSinglePictureProcessing` feature added in 0.0.19
- Updates tests to match the restored API signatures

## Problem

Version 0.0.18 introduced a typed API with `ImageScanResult`, `PdfScanResult`, `DocScanException`, input validation, and typed return values. Version 0.0.19 inadvertently removed all of these, reverting every method to `Future<dynamic>` with no error wrapping. This is a breaking change for any consumer that adopted the 0.0.18 typed API (e.g. using `ImageScanResult.images` or `ImageScanResult.count`).

Since pub's caret syntax (`^0.0.18`) resolves to `0.0.19`, a simple `flutter clean && flutter pub get` breaks existing code.

## What changed

| File | Change |
|---|---|
| `lib/flutter_doc_scanner_models.dart` | **Restored** — `ImageScanResult`, `PdfScanResult`, `ImageFormat` |
| `lib/flutter_doc_scanner_exception.dart` | **Restored** — `DocScanException` with error codes |
| `lib/flutter_doc_scanner.dart` | Typed returns, validation, exports, `useAutomaticSinglePictureProcessing` preserved |
| `lib/flutter_doc_scanner_platform_interface.dart` | Typed signatures with `imageFormat`, `quality`, `useAutomaticSinglePictureProcessing` |
| `lib/flutter_doc_scanner_method_channel.dart` | Passes all params, wraps `PlatformException` → `DocScanException` |
| `test/flutter_doc_scanner_test.dart` | Updated mock to match new signatures |

All existing tests pass.

Fixes #78