### PR TITLE
version and readme file update

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 0.0.20
+- Fixed breaking changes from 0.0.19
+- Restored typed models (ImageScanResult, PdfScanResult, DocScanException)
+
 ## 0.0.19
 - Added `useAutomaticSinglePictureProcessing` flag to enable a fast single-picture scanning mode optimized for quick one-document captures.
 - Implemented platform-specific optimizations (iOS custom auto-scan flow, Android fastest GMS mode) while preserving existing behavior by default.

--- a/README.md
+++ b/README.md
@@ -39,7 +39,7 @@ To use this plugin, add `flutter_doc_scanner` as a dependency in your `pubspec.y
 dependencies:
   flutter:
     sdk: flutter
-  flutter_doc_scanner: ^0.0.19
+  flutter_doc_scanner: ^0.0.20
 
 ```
 Got it! Here's a more detailed explanation:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: flutter_doc_scanner
 description: "A Flutter plugin for document scanning on Android and iOS using ML Kit Document Scanner API and VisionKit."
-version: 0.0.19
+version: 0.0.20
 homepage: https://github.com/shirsh94/flutter_doc_scanner/
 
 environment:


### PR DESCRIPTION
<html><head></head><body><p>Here’s a clean and professional version you can use for the PR description:</p><hr><h3><strong>Summary</strong></h3><ul><li><p>Restores the <code inline="">ImageScanResult</code>, <code inline="">PdfScanResult</code>, and <code inline="">DocScanException</code> classes that were removed in <code inline="">0.0.19</code></p></li><li><p>Reintroduces typed return values (<code inline="">Future&lt;ImageScanResult?&gt;</code>, <code inline="">Future&lt;PdfScanResult?&gt;</code>) in place of <code inline="">Future&lt;dynamic&gt;</code></p></li><li><p>Restores structured error handling using <code inline="">DocScanException</code> (wrapping <code inline="">PlatformException</code>)</p></li><li><p>Preserves the <code inline="">useAutomaticSinglePictureProcessing</code> feature introduced in <code inline="">0.0.19</code></p></li><li><p>Updates tests to align with the restored API signatures</p></li></ul><hr><h3><strong>Problem</strong></h3><p>Version <code inline="">0.0.18</code> introduced a strongly-typed API with models like <code inline="">ImageScanResult</code>, <code inline="">PdfScanResult</code>, and <code inline="">DocScanException</code>, along with input validation and structured error handling.</p><p>However, version <code inline="">0.0.19</code> unintentionally removed these improvements, reverting all methods to return <code inline="">Future&lt;dynamic&gt;</code> without proper error handling. This resulted in a <strong>breaking change</strong> for consumers relying on the typed API (e.g., accessing <code inline="">ImageScanResult.images</code> or <code inline="">ImageScanResult.count</code>).</p><p>Additionally, since Dart’s caret syntax (<code inline="">^0.0.18</code>) resolves to <code inline="">0.0.19</code>, running:</p><pre><code>flutter clean &amp;&amp; flutter pub get
</code></pre><p>causes existing implementations to break unexpectedly.</p><hr><h3><strong>What Changed</strong></h3>
This PR restores the typed API removed in 0.0.19 and is now ready for merge into main.

fix: restore typed models (ImageScanResult, PdfScanResult, DocScanException)
Closes #79